### PR TITLE
Use /bin/bash instead of /bin/sh

### DIFF
--- a/login.sh
+++ b/login.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ $# != 3 ]; then
   echo -e "ERROR! Wrong number of parameters!"

--- a/logout.sh
+++ b/logout.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ $# != 2 ]; then
   echo -e "ERROR! Wrong number of parameters!"

--- a/test_all_requests.sh
+++ b/test_all_requests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source rest.cfg
 
 TOKEN=$(./login.sh ${DSPACEURL} ${EMAIL} ${PASSWORD})


### PR DESCRIPTION
Despite the fact that `/bin/sh` is symlinked to `/bin/bash` on most systems these days (it's 2015!), bash still behaves like sh when called as sh. This causes the following critical error:

```
$ ./test_all_requests.sh
./test_all_requests.sh: line 2: source: rest.cfg: file not found
```
